### PR TITLE
Fixing missing versions for devDependencies.

### DIFF
--- a/applicationmenu-sample/package.json
+++ b/applicationmenu-sample/package.json
@@ -10,7 +10,7 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/businessrule-sample/package.json
+++ b/businessrule-sample/package.json
@@ -11,8 +11,8 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:",
-        "@servicenow/glide": "catalog:"
+        "@servicenow/glide": "^26.0.1",
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/businessrule-sample/src/fluent/business-rule.now.ts
+++ b/businessrule-sample/src/fluent/business-rule.now.ts
@@ -1,3 +1,4 @@
+import '@servicenow/sdk/global'
 import { BusinessRule } from '@servicenow/sdk/core'
 import { businessRuleProcess } from '../server/br-rule-module'
 

--- a/clientscript-sample/package.json
+++ b/clientscript-sample/package.json
@@ -10,7 +10,7 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/dependencies-sample/package.json
+++ b/dependencies-sample/package.json
@@ -11,7 +11,7 @@
         "dependencies": "now-sdk dependencies"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/dependencies-sample/src/fluent/generated/schema/global/sc_cat_item.ts
+++ b/dependencies-sample/src/fluent/generated/schema/global/sc_cat_item.ts
@@ -29,7 +29,14 @@ export const sc_cat_item = Table({
                 restricted: { label: 'Restricted', sequence: 2, inactive: false, language: 'en' },
             },
         }),
-        active: BooleanColumn({ mandatory: false, label: 'Active', read_only: false, active: true, default: true }),
+        active: BooleanColumn({
+            mandatory: false,
+            label: 'Active',
+            read_only: false,
+            active: true,
+            default: true,
+            maxLength: 40,
+        }),
         availability: StringColumn({
             mandatory: false,
             label: 'Availability',
@@ -44,13 +51,14 @@ export const sc_cat_item = Table({
                 on_desktop: { label: 'Desktop Only', sequence: 1, inactive: false, language: 'en' },
             },
         }),
-        billable: BooleanColumn({ mandatory: false, label: 'Billable', read_only: false, active: true }),
+        billable: BooleanColumn({ mandatory: false, label: 'Billable', read_only: false, active: true, maxLength: 40 }),
         category: ReferenceColumn({
             mandatory: false,
             label: 'Category',
             read_only: false,
             active: true,
             default: 'javascript: new SNCCatalogUtil().getCategoryIDFromURL();',
+            maxLength: 32,
             referenceTable: 'sc_category',
         }),
         checked_out: StringColumn({
@@ -65,12 +73,20 @@ export const sc_cat_item = Table({
                 false: { label: 'false', sequence: 2, inactive: false, language: 'en' },
             },
         }),
-        cost: DecimalColumn({ mandatory: false, label: 'Cost', read_only: false, active: true, default: 0 }),
+        cost: DecimalColumn({
+            mandatory: false,
+            label: 'Cost',
+            read_only: false,
+            active: true,
+            default: 0,
+            maxLength: 15,
+        }),
         custom_cart: ReferenceColumn({
             mandatory: false,
             label: 'Cart',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sys_ui_macro',
         }),
         delivery_plan: ReferenceColumn({
@@ -79,6 +95,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: 'javascript:getDefaultDeliveryPlan()',
+            maxLength: 32,
             referenceTable: 'sc_cat_item_delivery_plan',
         }),
         delivery_plan_script: GenericColumn({
@@ -86,6 +103,7 @@ export const sc_cat_item = Table({
             label: 'Delivery plan script',
             read_only: false,
             active: true,
+            maxLength: 4000,
             column_type: 'script_plain',
         }),
         delivery_time: GenericColumn({
@@ -94,6 +112,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: '2 00:00:00',
+            maxLength: 40,
             column_type: 'glide_duration',
         }),
         description: GenericColumn({
@@ -101,6 +120,7 @@ export const sc_cat_item = Table({
             label: 'Description',
             read_only: false,
             active: true,
+            maxLength: 8000,
             column_type: 'translated_html',
         }),
         display_price_property: StringColumn({
@@ -116,6 +136,7 @@ export const sc_cat_item = Table({
             label: 'Entitlement script',
             read_only: false,
             active: true,
+            maxLength: 4000,
             column_type: 'script_plain',
         }),
         flow_designer_flow: ReferenceColumn({
@@ -123,6 +144,7 @@ export const sc_cat_item = Table({
             label: 'Flow',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sys_hub_flow',
         }),
         fulfillment_automation_level: StringColumn({
@@ -145,6 +167,7 @@ export const sc_cat_item = Table({
             label: 'Fulfillment group',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sys_user_group',
         }),
         hide_sp: BooleanColumn({
@@ -153,12 +176,14 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         icon: GenericColumn({
             mandatory: false,
             label: 'Icon',
             read_only: false,
             active: true,
+            maxLength: 40,
             column_type: 'user_image',
         }),
         ignore_price: BooleanColumn({
@@ -167,12 +192,14 @@ export const sc_cat_item = Table({
             read_only: true,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         image: GenericColumn({
             mandatory: false,
             label: 'Image',
             read_only: false,
             active: true,
+            maxLength: 40,
             column_type: 'image',
         }),
         list_price: GenericColumn({
@@ -180,6 +207,7 @@ export const sc_cat_item = Table({
             label: 'List Price',
             read_only: false,
             active: true,
+            maxLength: 20,
             column_type: 'currency',
         }),
         location: ReferenceColumn({
@@ -187,6 +215,7 @@ export const sc_cat_item = Table({
             label: 'Location',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'cmn_location',
         }),
         make_item_non_conversational: BooleanColumn({
@@ -194,12 +223,14 @@ export const sc_cat_item = Table({
             label: 'Make the item non-conversational in VA',
             read_only: false,
             active: true,
+            maxLength: 40,
         }),
         mandatory_attachment: BooleanColumn({
             mandatory: false,
             label: 'Mandatory Attachment',
             read_only: false,
             active: true,
+            maxLength: 40,
         }),
         meta: StringColumn({
             mandatory: false,
@@ -215,12 +246,14 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         mobile_picture: GenericColumn({
             mandatory: false,
             label: 'Classic Mobile Picture',
             read_only: false,
             active: true,
+            maxLength: 40,
             column_type: 'user_image',
         }),
         mobile_picture_type: StringColumn({
@@ -242,17 +275,38 @@ export const sc_cat_item = Table({
             label: 'Model',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'cmdb_model',
         }),
-        name: TranslatedTextColumn({ mandatory: false, label: 'Name', read_only: false, active: true }),
-        no_attachment_v2: BooleanColumn({ mandatory: false, label: 'Hide Attachment', read_only: false, active: true }),
-        no_cart: BooleanColumn({ mandatory: false, label: 'No cart', read_only: false, active: true, default: false }),
-        no_cart_v2: BooleanColumn({ mandatory: false, label: "Hide 'Add to Cart'", read_only: false, active: true }),
+        name: TranslatedTextColumn({ mandatory: false, label: 'Name', read_only: false, active: true, maxLength: 100 }),
+        no_attachment_v2: BooleanColumn({
+            mandatory: false,
+            label: 'Hide Attachment',
+            read_only: false,
+            active: true,
+            maxLength: 40,
+        }),
+        no_cart: BooleanColumn({
+            mandatory: false,
+            label: 'No cart',
+            read_only: false,
+            active: true,
+            default: false,
+            maxLength: 40,
+        }),
+        no_cart_v2: BooleanColumn({
+            mandatory: false,
+            label: "Hide 'Add to Cart'",
+            read_only: false,
+            active: true,
+            maxLength: 40,
+        }),
         no_delivery_time_v2: BooleanColumn({
             mandatory: false,
             label: 'Hide Delivery time',
             read_only: false,
             active: true,
+            maxLength: 40,
         }),
         no_order: BooleanColumn({
             mandatory: false,
@@ -260,6 +314,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         no_order_now: BooleanColumn({
             mandatory: false,
@@ -267,6 +322,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         no_proceed_checkout: BooleanColumn({
             mandatory: false,
@@ -274,6 +330,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         no_quantity: BooleanColumn({
             mandatory: false,
@@ -281,13 +338,21 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
-        no_quantity_v2: BooleanColumn({ mandatory: false, label: 'Hide Quantity', read_only: false, active: true }),
+        no_quantity_v2: BooleanColumn({
+            mandatory: false,
+            label: 'Hide Quantity',
+            read_only: false,
+            active: true,
+            maxLength: 40,
+        }),
         no_save_as_draft: BooleanColumn({
             mandatory: false,
             label: "Hide 'Save as Draft'",
             read_only: false,
             active: true,
+            maxLength: 40,
         }),
         no_search: BooleanColumn({
             mandatory: false,
@@ -295,12 +360,14 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         no_wishlist_v2: BooleanColumn({
             mandatory: false,
             label: "Hide 'Add to Wish List'",
             read_only: false,
             active: true,
+            maxLength: 40,
         }),
         omit_price: BooleanColumn({
             mandatory: false,
@@ -308,6 +375,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         order: IntegerColumn({
             mandatory: false,
@@ -322,6 +390,7 @@ export const sc_cat_item = Table({
             label: 'Ordered item link',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sc_ordered_item_link',
         }),
         owner: ReferenceColumn({
@@ -330,6 +399,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: 'javascript:gs.getUserID()',
+            maxLength: 32,
             referenceTable: 'sys_user',
         }),
         picture: GenericColumn({
@@ -337,6 +407,7 @@ export const sc_cat_item = Table({
             label: 'Picture',
             read_only: false,
             active: true,
+            maxLength: 40,
             column_type: 'user_image',
         }),
         preview: GenericColumn({
@@ -344,6 +415,7 @@ export const sc_cat_item = Table({
             label: 'Preview link',
             read_only: false,
             active: true,
+            maxLength: 255,
             column_type: 'catalog_preview',
         }),
         price: GenericColumn({
@@ -352,6 +424,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: '0.00',
+            maxLength: 20,
             column_type: 'price',
         }),
         published_ref: ReferenceColumn({
@@ -359,6 +432,7 @@ export const sc_cat_item = Table({
             label: 'Published item',
             read_only: true,
             active: true,
+            maxLength: 32,
             referenceTable: 'sc_cat_item',
         }),
         recurring_frequency: ChoiceColumn({
@@ -368,12 +442,14 @@ export const sc_cat_item = Table({
             label: 'Recurring Price Frequency',
             read_only: false,
             active: true,
+            maxLength: 40,
         }),
         recurring_price: GenericColumn({
             mandatory: false,
             label: 'Recurring price',
             read_only: false,
             active: true,
+            maxLength: 20,
             column_type: 'price',
         }),
         request_method: StringColumn({
@@ -384,18 +460,19 @@ export const sc_cat_item = Table({
             maxLength: 40,
             dropdown: 'dropdown_with_none',
             choices: {
+                submit: { label: 'Submit', sequence: 3, inactive: false, language: 'en' },
                 NULL_OVERRIDE: { label: 'Order', sequence: 1, inactive: false, language: 'en' },
                 request: { label: 'Request', sequence: 2, inactive: false, language: 'en' },
-                submit: { label: 'Submit', sequence: 3, inactive: false, language: 'en' },
             },
         }),
-        roles: UserRolesColumn({ mandatory: false, label: 'Roles', read_only: false, active: true }),
+        roles: UserRolesColumn({ mandatory: false, label: 'Roles', read_only: false, active: true, maxLength: 255 }),
         sc_catalogs: GenericColumn({
             mandatory: false,
             label: 'Catalogs',
             read_only: false,
             active: true,
             default: 'javascript:SNC.Catalog.getDefaultCatalog();',
+            maxLength: 4000,
             column_type: 'glide_list',
         }),
         sc_ic_item_staging: ReferenceColumn({
@@ -403,6 +480,7 @@ export const sc_cat_item = Table({
             label: 'Created from item design',
             read_only: true,
             active: true,
+            maxLength: 32,
             referenceTable: 'sc_ic_item_staging',
         }),
         sc_ic_version: IntegerColumn({
@@ -417,6 +495,7 @@ export const sc_cat_item = Table({
             label: 'Associated template',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sc_template',
         }),
         short_description: TranslatedTextColumn({
@@ -424,6 +503,7 @@ export const sc_cat_item = Table({
             label: 'Short description',
             read_only: false,
             active: true,
+            maxLength: 200,
         }),
         show_variable_help_on_load: BooleanColumn({
             mandatory: false,
@@ -431,8 +511,15 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
-        start_closed: BooleanColumn({ mandatory: false, label: 'Start closed', read_only: false, active: true }),
+        start_closed: BooleanColumn({
+            mandatory: false,
+            label: 'Start closed',
+            read_only: false,
+            active: true,
+            maxLength: 40,
+        }),
         state: StringColumn({
             mandatory: false,
             label: 'State',
@@ -453,6 +540,7 @@ export const sc_cat_item = Table({
             label: 'Sys ID',
             read_only: false,
             active: true,
+            maxLength: 32,
             column_type: 'GUID',
         }),
         taxonomy_topic: ReferenceColumn({
@@ -460,6 +548,7 @@ export const sc_cat_item = Table({
             label: 'Taxonomy topic',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'topic',
         }),
         template: ReferenceColumn({
@@ -467,6 +556,7 @@ export const sc_cat_item = Table({
             label: 'Template',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sys_template',
         }),
         template_manager_roles: UserRolesColumn({
@@ -474,6 +564,7 @@ export const sc_cat_item = Table({
             label: 'Template Manager roles',
             read_only: false,
             active: true,
+            maxLength: 255,
         }),
         type: StringColumn({
             mandatory: false,
@@ -497,12 +588,14 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: true,
+            maxLength: 40,
         }),
         vendor: ReferenceColumn({
             mandatory: false,
             label: 'Vendor',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'core_company',
         }),
         version: IntegerColumn({ mandatory: false, label: 'Version', read_only: true, active: true, maxLength: 40 }),
@@ -512,6 +605,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: true,
+            maxLength: 40,
         }),
         visible_guide: BooleanColumn({
             mandatory: false,
@@ -519,6 +613,7 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: true,
+            maxLength: 40,
         }),
         visible_standalone: BooleanColumn({
             mandatory: false,
@@ -526,12 +621,14 @@ export const sc_cat_item = Table({
             read_only: false,
             active: true,
             default: true,
+            maxLength: 40,
         }),
         workflow: ReferenceColumn({
             mandatory: false,
             label: 'Workflow',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'wf_workflow',
         }),
     },

--- a/dependencies-sample/src/fluent/generated/schema/global/sys_metadata.ts
+++ b/dependencies-sample/src/fluent/generated/schema/global/sys_metadata.ts
@@ -18,6 +18,7 @@ export const sys_metadata = Table({
             read_only: false,
             active: true,
             default: 'javascript:current.getTableName();',
+            maxLength: 80,
         }),
         sys_created_by: StringColumn({
             mandatory: false,
@@ -27,12 +28,19 @@ export const sys_metadata = Table({
             maxLength: 40,
             dropdown: 'none',
         }),
-        sys_created_on: DateTimeColumn({ mandatory: false, label: 'Created', read_only: false, active: true }),
+        sys_created_on: DateTimeColumn({
+            mandatory: false,
+            label: 'Created',
+            read_only: false,
+            active: true,
+            maxLength: 40,
+        }),
         sys_id: GenericColumn({
             mandatory: true,
             label: 'Sys ID',
             read_only: false,
             active: true,
+            maxLength: 32,
             column_type: 'GUID',
         }),
         sys_mod_count: IntegerColumn({
@@ -55,6 +63,7 @@ export const sys_metadata = Table({
             label: 'Package',
             read_only: true,
             active: true,
+            maxLength: 32,
             referenceTable: 'sys_package',
         }),
         sys_policy: StringColumn({
@@ -65,8 +74,8 @@ export const sys_metadata = Table({
             maxLength: 40,
             dropdown: 'dropdown_with_none',
             choices: {
-                protected: { label: 'Protected', sequence: 2, inactive: false, language: 'en' },
                 read: { label: 'Read-only', sequence: 1, inactive: false, language: 'en' },
+                protected: { label: 'Protected', sequence: 2, inactive: false, language: 'en' },
             },
         }),
         sys_scope: ReferenceColumn({
@@ -76,6 +85,7 @@ export const sys_metadata = Table({
             active: true,
             default:
                 "javascript:(((typeof parent == 'object') && parent != null && parent.getTableName() == 'sys_app') ? parent.sys_id : gs.getCurrentApplicationId())",
+            maxLength: 32,
             referenceTable: 'sys_scope',
         }),
         sys_update_name: StringColumn({
@@ -94,6 +104,12 @@ export const sys_metadata = Table({
             maxLength: 40,
             dropdown: 'none',
         }),
-        sys_updated_on: DateTimeColumn({ mandatory: false, label: 'Updated', read_only: false, active: true }),
+        sys_updated_on: DateTimeColumn({
+            mandatory: false,
+            label: 'Updated',
+            read_only: false,
+            active: true,
+            maxLength: 40,
+        }),
     },
 })

--- a/dependencies-sample/src/fluent/generated/schema/global/sys_ui_action.ts
+++ b/dependencies-sample/src/fluent/generated/schema/global/sys_ui_action.ts
@@ -25,13 +25,28 @@ export const sys_ui_action = Table({
             maxLength: 40,
             dropdown: 'none',
         }),
-        active: BooleanColumn({ mandatory: false, label: 'Active', read_only: false, active: true, default: true }),
-        client: BooleanColumn({ mandatory: false, label: 'Client', read_only: false, active: true, default: false }),
+        active: BooleanColumn({
+            mandatory: false,
+            label: 'Active',
+            read_only: false,
+            active: true,
+            default: true,
+            maxLength: 40,
+        }),
+        client: BooleanColumn({
+            mandatory: false,
+            label: 'Client',
+            read_only: false,
+            active: true,
+            default: false,
+            maxLength: 40,
+        }),
         client_script_v2: ScriptColumn({
             mandatory: false,
             label: 'Workspace Client Script',
             read_only: false,
             active: true,
+            maxLength: 8000,
         }),
         comments: StringColumn({
             mandatory: false,
@@ -45,15 +60,23 @@ export const sys_ui_action = Table({
             label: 'Condition',
             read_only: false,
             active: true,
+            maxLength: 254,
             column_type: 'condition_string',
         }),
-        form_action: BooleanColumn({ mandatory: false, label: 'Form action', read_only: false, active: true }),
+        form_action: BooleanColumn({
+            mandatory: false,
+            label: 'Form action',
+            read_only: false,
+            active: true,
+            maxLength: 40,
+        }),
         form_button: BooleanColumn({
             mandatory: false,
             label: 'Form button',
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         form_button_v2: BooleanColumn({
             mandatory: false,
@@ -61,6 +84,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         form_context_menu: BooleanColumn({
             mandatory: false,
@@ -68,6 +92,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         form_link: BooleanColumn({
             mandatory: false,
@@ -75,6 +100,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         form_menu_button_v2: BooleanColumn({
             mandatory: false,
@@ -82,6 +108,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         form_style: StringColumn({
             mandatory: false,
@@ -91,9 +118,9 @@ export const sys_ui_action = Table({
             maxLength: 40,
             dropdown: 'dropdown_with_none',
             choices: {
+                destructive: { label: 'Destructive', sequence: 2, inactive: false, language: 'en' },
                 unstyled: { label: 'Unstyled', sequence: 3, inactive: false, language: 'en' },
                 primary: { label: 'Primary', sequence: 1, inactive: false, language: 'en' },
-                destructive: { label: 'Destructive', sequence: 2, inactive: false, language: 'en' },
             },
         }),
         format_for_configurable_workspace: BooleanColumn({
@@ -102,22 +129,37 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
-        hint: TranslatedFieldColumn({ mandatory: false, label: 'Hint', read_only: false, active: true }),
+        hint: TranslatedFieldColumn({
+            mandatory: false,
+            label: 'Hint',
+            read_only: false,
+            active: true,
+            maxLength: 254,
+        }),
         isolate_script: BooleanColumn({
             mandatory: false,
             label: 'Isolate script',
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
-        list_action: BooleanColumn({ mandatory: false, label: 'List action', read_only: false, active: true }),
+        list_action: BooleanColumn({
+            mandatory: false,
+            label: 'List action',
+            read_only: false,
+            active: true,
+            maxLength: 40,
+        }),
         list_banner_button: BooleanColumn({
             mandatory: false,
             label: 'List banner button',
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         list_button: BooleanColumn({
             mandatory: false,
@@ -125,6 +167,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         list_choice: BooleanColumn({
             mandatory: false,
@@ -132,6 +175,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         list_context_menu: BooleanColumn({
             mandatory: false,
@@ -139,6 +183,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         list_link: BooleanColumn({
             mandatory: false,
@@ -146,6 +191,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         list_save_with_form_button: BooleanColumn({
             mandatory: false,
@@ -153,6 +199,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         list_style: StringColumn({
             mandatory: false,
@@ -162,9 +209,9 @@ export const sys_ui_action = Table({
             maxLength: 40,
             dropdown: 'dropdown_with_none',
             choices: {
+                unstyled: { label: 'Unstyled', sequence: 3, inactive: false, language: 'en' },
                 primary: { label: 'Primary', sequence: 1, inactive: false, language: 'en' },
                 destructive: { label: 'Destructive', sequence: 2, inactive: false, language: 'en' },
-                unstyled: { label: 'Unstyled', sequence: 3, inactive: false, language: 'en' },
             },
         }),
         messages: StringColumn({
@@ -175,7 +222,7 @@ export const sys_ui_action = Table({
             maxLength: 4000,
             dropdown: 'none',
         }),
-        name: TranslatedFieldColumn({ mandatory: false, label: 'Name', read_only: false, active: true }),
+        name: TranslatedFieldColumn({ mandatory: false, label: 'Name', read_only: false, active: true, maxLength: 40 }),
         onclick: StringColumn({
             mandatory: false,
             label: 'Onclick',
@@ -192,13 +239,14 @@ export const sys_ui_action = Table({
             default: 100,
             maxLength: 40,
         }),
-        script: ScriptColumn({ mandatory: false, label: 'Script', read_only: false, active: true }),
+        script: ScriptColumn({ mandatory: false, label: 'Script', read_only: false, active: true, maxLength: 8000 }),
         show_insert: BooleanColumn({
             mandatory: false,
             label: 'Show insert',
             read_only: false,
             active: true,
             default: true,
+            maxLength: 40,
         }),
         show_multiple_update: BooleanColumn({
             mandatory: false,
@@ -206,6 +254,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         show_query: BooleanColumn({
             mandatory: false,
@@ -213,6 +262,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
         show_update: BooleanColumn({
             mandatory: false,
@@ -220,6 +270,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: true,
+            maxLength: 40,
         }),
         sys_domain: DomainIdColumn({
             mandatory: false,
@@ -227,6 +278,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: 'global',
+            maxLength: 32,
         }),
         sys_domain_path: DomainPathColumn({
             mandatory: false,
@@ -234,12 +286,14 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: '/',
+            maxLength: 255,
         }),
         sys_id: GenericColumn({
             mandatory: false,
             label: 'Sys ID',
             read_only: false,
             active: true,
+            maxLength: 32,
             column_type: 'GUID',
         }),
         sys_overrides: ReferenceColumn({
@@ -247,15 +301,17 @@ export const sys_ui_action = Table({
             label: 'Overrides',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sys_ui_action',
         }),
-        table: TableNameColumn({ mandatory: false, label: 'Table', read_only: false, active: true }),
+        table: TableNameColumn({ mandatory: false, label: 'Table', read_only: false, active: true, maxLength: 80 }),
         ui11_compatible: BooleanColumn({
             mandatory: false,
             label: 'List v2 Compatible',
             read_only: false,
             active: true,
             default: true,
+            maxLength: 40,
         }),
         ui16_compatible: BooleanColumn({
             mandatory: false,
@@ -263,6 +319,7 @@ export const sys_ui_action = Table({
             read_only: false,
             active: true,
             default: false,
+            maxLength: 40,
         }),
     },
 })

--- a/dependencies-sample/src/fluent/generated/schema/global/sys_ui_action_role.ts
+++ b/dependencies-sample/src/fluent/generated/schema/global/sys_ui_action_role.ts
@@ -10,6 +10,7 @@ export const sys_ui_action_role = Table({
             label: 'Sys ID',
             read_only: false,
             active: true,
+            maxLength: 32,
             column_type: 'GUID',
         }),
         sys_ui_action: ReferenceColumn({
@@ -17,6 +18,7 @@ export const sys_ui_action_role = Table({
             label: 'UI Action',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sys_ui_action',
         }),
         sys_user_role: ReferenceColumn({
@@ -24,6 +26,7 @@ export const sys_ui_action_role = Table({
             label: 'Role',
             read_only: false,
             active: true,
+            maxLength: 32,
             referenceTable: 'sys_user_role',
         }),
     },

--- a/dependencies-sample/src/fluent/generated/schema/tables.ts
+++ b/dependencies-sample/src/fluent/generated/schema/tables.ts
@@ -2,22 +2,22 @@
 
 import '@servicenow/sdk/global'
 import { Table } from '@servicenow/sdk/core'
-import { sys_ui_action } from './global/sys_ui_action'
 import { sc_cat_item } from './global/sc_cat_item'
+import { sys_ui_action } from './global/sys_ui_action'
 import { sys_ui_action_role } from './global/sys_ui_action_role'
 import { sys_metadata } from './global/sys_metadata'
 declare global {
     namespace Now {
         namespace Internal {
             namespace TableSchemas {
-                interface sys_ui_action extends Helper<typeof sys_ui_action> {}
                 interface sc_cat_item extends Helper<typeof sc_cat_item> {}
+                interface sys_ui_action extends Helper<typeof sys_ui_action> {}
                 interface sys_ui_action_role extends Helper<typeof sys_ui_action_role> {}
                 interface sys_metadata extends Helper<typeof sys_metadata> {}
             }
             interface Tables {
-                sys_ui_action: Table<TableSchemas.sys_ui_action, 'sys_metadata'>
                 sc_cat_item: Table<TableSchemas.sc_cat_item, 'sys_metadata'>
+                sys_ui_action: Table<TableSchemas.sys_ui_action, 'sys_metadata'>
                 sys_ui_action_role: Table<TableSchemas.sys_ui_action_role, 'sys_metadata'>
                 sys_metadata: Table<TableSchemas.sys_metadata>
             }

--- a/hello-world-sample/package.json
+++ b/hello-world-sample/package.json
@@ -10,8 +10,8 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/glide": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/glide": "^26.0.1",
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/list-sample/package.json
+++ b/list-sample/package.json
@@ -10,7 +10,7 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/record-sample/package.json
+++ b/record-sample/package.json
@@ -10,7 +10,7 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/restapi-sample/package.json
+++ b/restapi-sample/package.json
@@ -10,8 +10,8 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/glide": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/glide": "^26.0.1",
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/sys_module-sample/package.json
+++ b/sys_module-sample/package.json
@@ -10,7 +10,7 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/table-sample/package.json
+++ b/table-sample/package.json
@@ -10,7 +10,7 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }

--- a/test-atf-sample/package.json
+++ b/test-atf-sample/package.json
@@ -10,7 +10,7 @@
         "fetch": "now-sdk fetch"
     },
     "devDependencies": {
-        "typescript": "catalog:",
-        "@servicenow/sdk": "catalog:"
+        "@servicenow/sdk": "^2.1.3",
+        "typescript": "5.5.2"
     }
 }


### PR DESCRIPTION
Fixed versions for devDependencies so that it will build for non-pnpm users like myself and our customers.

The now-sdk build process seems to have reformatted the generated code to be formatted with line breaks.  Since the tool did that I have included that here for consistency in the future.