### PR TITLE
Fixing "cannot load module" error in module and br projects

### DIFF
--- a/businessrule-sample/now.config.json
+++ b/businessrule-sample/now.config.json
@@ -1,5 +1,7 @@
 {
-  "scope": "x_restapimodules",
-  "scopeId": "fc1b5713c3db3110d6489a038a40dd83",
-  "transpiledSourceDir": "dist/modules"
+  "scope": "x_br_sample",
+  "scopeId": "fc1b5713c3db3110d6489a038a40dd84",
+  "modulePaths": {
+    "src/server/*.ts": "dist/server/*.js"
+  }
 }

--- a/businessrule-sample/package.json
+++ b/businessrule-sample/package.json
@@ -5,14 +5,16 @@
     "keywords": [],
     "author": "ServiceNow",
     "license": "ISC",
-    "module": "esnext",
     "scripts": {
         "build": "tsc -b && now-sdk build",
-        "fetch": "now-sdk fetch"
+        "fetch": "now-sdk fetch",
+        "deploy": "now-sdk deploy",
+        "dependencies": "now-sdk dependencies"
     },
     "devDependencies": {
         "@servicenow/glide": "^26.0.1",
         "@servicenow/sdk": "^2.1.3",
-        "typescript": "5.5.2"
+        "typescript": "5.5.2",
+        "@types/node": "20.0.0"
     }
 }

--- a/businessrule-sample/tsconfig.json
+++ b/businessrule-sample/tsconfig.json
@@ -7,14 +7,14 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "isolatedModules": true,
-    "target": "ES2022",
-    "module": "Node16"
+    "target": "ES2022"
   },
   "include": [
     "src"
   ],
   "exclude": [
     "dist",
-    "node_modules"
+    "node_modules",
+    "src/fluent"
   ],
 }

--- a/clientscript-sample/package.json
+++ b/clientscript-sample/package.json
@@ -11,6 +11,6 @@
     },
     "devDependencies": {
         "@servicenow/sdk": "^2.1.3",
-        "typescript": "5.5.2"
+        "typescript": "^5.5.2"
     }
 }

--- a/sys_module-sample/now.config.json
+++ b/sys_module-sample/now.config.json
@@ -1,5 +1,7 @@
 {
     "scope": "x_sysmodulesample",
     "scopeId": "fc1b5713c3db3110d6489a038a40dd83",
-    "transpiledSourceDir": "dist/modules"
+    "modulePaths": {
+        "src/server/*.ts": "dist/server/*.js"
+    }
 }

--- a/sys_module-sample/package.json
+++ b/sys_module-sample/package.json
@@ -7,10 +7,13 @@
     "license": "ISC",
     "scripts": {
         "build": "tsc -b && now-sdk build",
-        "fetch": "now-sdk fetch"
+        "fetch": "now-sdk fetch",
+        "deploy": "now-sdk deploy",
+        "dependencies": "now-sdk dependencies"
     },
     "devDependencies": {
         "@servicenow/sdk": "^2.1.3",
-        "typescript": "5.5.2"
+        "typescript": "5.5.2",
+        "@types/node": "20.0.0"
     }
 }

--- a/sys_module-sample/src/fluent/script-include-module-one.now.ts
+++ b/sys_module-sample/src/fluent/script-include-module-one.now.ts
@@ -14,7 +14,9 @@ Record({
         mobile_callable: false,
         name: 'SampleClass',
         sandbox_callable: false,
-        script: "const sinc = require('./src/server/sample-class.js'); var SampleClass = sinc.SampleClass;",
+        script: script`const sinc = require('./dist/server/sample-class.js'); 
+var SampleClass = sinc.SampleClass;
+`,
         sys_name: 'SampleClass',
     },
 })

--- a/sys_module-sample/tsconfig.json
+++ b/sys_module-sample/tsconfig.json
@@ -4,7 +4,10 @@
     "rootDir": "src",
     "noEmit": false,
     "strict": true,
-    "target": "ES2020"
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "target": "ES2022"
   },
   "include": [
     "src"


### PR DESCRIPTION
Resolving issue where you get `Cannot find module '@servicenow/sdk/core'` errors when trying to build.  This was caused by unnecessary "module" entries in package.json and not excluding src/fluent in the now.config.json.  Also removed "transpiledSourceDir" property from now.config.json.